### PR TITLE
Add Our Team navigation section and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,6 +119,10 @@
           <img src="about-icon.png" alt="About" class="nav-img">
           <span>About</span>
         </a>
+        <a href="#team" class="nav-icon">
+          <img src="default-avatar.png" alt="Our Team" class="nav-img">
+          <span>Our Team</span>
+        </a>
       </div>
       <div class="nav-right">
         <div class="credits-display">
@@ -429,6 +433,157 @@
               <span class="social-icon">📺</span>
               <span class="social-text" data-translate="youtube">YouTube</span>
             </a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="team" style="display: none;">
+      <div class="team-section">
+        <div class="team-header">
+          <h2>Our Team</h2>
+          <p>Meet the passionate people guiding the Nepal Stock Simulator and supporting our community of investors.</p>
+        </div>
+
+        <div class="team-category">
+          <div class="category-header">
+            <span class="category-label management">Management &amp; Operations</span>
+          </div>
+          <div class="team-grid">
+            <article class="team-card leader management-card">
+              <div class="member-avatar">
+                <img src="subigya.png" alt="Subigya Raj Kharel" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">SRK</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">Chief Executive Officer</p>
+                <h3 class="member-name">Subigya Raj Kharel</h3>
+              </div>
+            </article>
+            <article class="team-card management-card">
+              <div class="member-avatar">
+                <img src="angi.png" alt="Angi Rijal" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">AR</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">Chief Operating Officer</p>
+                <h3 class="member-name">Angi Rijal</h3>
+              </div>
+            </article>
+            <article class="team-card management-card">
+              <div class="member-avatar">
+                <img src="nayan.png" alt="Nayan Shakya" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">NS</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">Managing Director</p>
+                <h3 class="member-name">Nayan Shakya</h3>
+              </div>
+            </article>
+            <article class="team-card management-card">
+              <div class="member-avatar">
+                <img src="abhinav.png" alt="Abhinav Pyakurel" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">AP</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">Deputy Chief Operating Officer</p>
+                <h3 class="member-name">Abhinav Pyakurel</h3>
+              </div>
+            </article>
+          </div>
+        </div>
+
+        <div class="team-category">
+          <div class="category-header">
+            <span class="category-label research">Research &amp; Development</span>
+          </div>
+          <div class="team-grid">
+            <article class="team-card research-card">
+              <div class="member-avatar">
+                <img src="aarohan.png" alt="Aarohan Timalsina" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">AT</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">AI Researcher</p>
+                <h3 class="member-name">Aarohan Timalsina</h3>
+              </div>
+            </article>
+            <article class="team-card research-card">
+              <div class="member-avatar">
+                <img src="aayim.png" alt="Aayim Rijal" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">AR</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">Chief Technology Officer</p>
+                <h3 class="member-name">Aayim Rijal</h3>
+              </div>
+            </article>
+            <article class="team-card research-card">
+              <div class="member-avatar">
+                <img src="samyam.png" alt="Samyam Giri" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">SG</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">SVP of Research</p>
+                <h3 class="member-name">Samyam Giri</h3>
+              </div>
+            </article>
+          </div>
+        </div>
+
+        <div class="team-category">
+          <div class="category-header">
+            <span class="category-label finance">Finances</span>
+          </div>
+          <div class="team-grid single">
+            <article class="team-card finance-card">
+              <div class="member-avatar">
+                <img src="rachit.png" alt="Rachit Bhattarai" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">RB</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">Chief Financial Officer</p>
+                <h3 class="member-name">Rachit Bhattarai</h3>
+              </div>
+            </article>
+          </div>
+        </div>
+
+        <div class="team-category">
+          <div class="category-header">
+            <span class="category-label marketing">Marketing &amp; Communications</span>
+          </div>
+          <div class="team-grid">
+            <article class="team-card marketing-card">
+              <div class="member-avatar">
+                <img src="rushka.png" alt="Rushka Sapkota" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">RS</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">Chief Marketing Officer</p>
+                <h3 class="member-name">Rushka Sapkota</h3>
+              </div>
+            </article>
+            <article class="team-card marketing-card">
+              <div class="member-avatar">
+                <img src="sanskari.png" alt="Sanskari Sharma" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">SS</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">Content &amp; Communications</p>
+                <h3 class="member-name">Sanskari Sharma</h3>
+              </div>
+            </article>
+            <article class="team-card marketing-card">
+              <div class="member-avatar">
+                <img src="aarav.png" alt="Aarav Dahal" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">AD</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">VP of Communications</p>
+                <h3 class="member-name">Aarav Dahal</h3>
+              </div>
+            </article>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -462,12 +462,12 @@
             </article>
             <article class="team-card management-card">
               <div class="member-avatar">
-                <img src="angi.png" alt="Angi Rijal" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <img src="agraj.png" alt="Agraj Rijal" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
                 <span class="member-initials" aria-hidden="true">AR</span>
               </div>
               <div class="member-info">
                 <p class="member-role">Chief Operating Officer</p>
-                <h3 class="member-name">Angi Rijal</h3>
+                <h3 class="member-name">Agraj Rijal</h3>
               </div>
             </article>
             <article class="team-card management-card">
@@ -500,32 +500,32 @@
           <div class="team-grid">
             <article class="team-card research-card">
               <div class="member-avatar">
-                <img src="aarohan.png" alt="Aarohan Timalsina" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <img src="aarohan.png" alt="Aarohan Timsina" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
                 <span class="member-initials" aria-hidden="true">AT</span>
               </div>
               <div class="member-info">
-                <p class="member-role">AI Researcher</p>
-                <h3 class="member-name">Aarohan Timalsina</h3>
+                <p class="member-role">Chief Research Officer</p>
+                <h3 class="member-name">Aarohan Timsina</h3>
               </div>
             </article>
             <article class="team-card research-card">
               <div class="member-avatar">
-                <img src="aayim.png" alt="Aayim Rijal" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <img src="agrim.png" alt="Agrim Rijal" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
                 <span class="member-initials" aria-hidden="true">AR</span>
               </div>
               <div class="member-info">
                 <p class="member-role">Chief Technology Officer</p>
-                <h3 class="member-name">Aayim Rijal</h3>
+                <h3 class="member-name">Agrim Rijal</h3>
               </div>
             </article>
             <article class="team-card research-card">
               <div class="member-avatar">
-                <img src="samyam.png" alt="Samyam Giri" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <img src="syon.png" alt="Syon Lama" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
                 <span class="member-initials" aria-hidden="true">SG</span>
               </div>
               <div class="member-info">
-                <p class="member-role">SVP of Research</p>
-                <h3 class="member-name">Samyam Giri</h3>
+                <p class="member-role">VP of Research</p>
+                <h3 class="member-name">Syon Lama</h3>
               </div>
             </article>
           </div>
@@ -566,12 +566,12 @@
             </article>
             <article class="team-card marketing-card">
               <div class="member-avatar">
-                <img src="sanskari.png" alt="Sanskari Sharma" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <img src="sanskar.png" alt="Sanskar Sharma" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
                 <span class="member-initials" aria-hidden="true">SS</span>
               </div>
               <div class="member-info">
                 <p class="member-role">Content &amp; Communications</p>
-                <h3 class="member-name">Sanskari Sharma</h3>
+                <h3 class="member-name">Sanskar Sharma</h3>
               </div>
             </article>
             <article class="team-card marketing-card">
@@ -633,4 +633,5 @@
   <script src="nss.js"></script>
 </body>
 </html>
+
 

--- a/nss.css
+++ b/nss.css
@@ -499,6 +499,188 @@ section {
   }
 }
 
+/* Team Section */
+.team-section {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.team-header {
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.team-header h2 {
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.team-header p {
+  margin: 0;
+  color: #555;
+  font-size: 1.05rem;
+}
+
+.team-category {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.category-header {
+  display: flex;
+  align-items: center;
+}
+
+.category-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  padding: 0.35rem 1.1rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}
+
+.category-label.management {
+  background-color: #ffe9d6;
+  color: #d35400;
+  border: 2px solid #ffb26b;
+}
+
+.category-label.research {
+  background-color: #dff0ff;
+  color: #0f62a9;
+  border: 2px solid #5dade2;
+}
+
+.category-label.finance {
+  background-color: #fff5d6;
+  color: #b78600;
+  border: 2px solid #f6c343;
+}
+
+.category-label.marketing {
+  background-color: #e0f6e9;
+  color: #1f7a45;
+  border: 2px solid #4cd964;
+}
+
+.team-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.team-grid.single {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.team-card {
+  background: var(--card-background);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 24px rgba(15, 24, 44, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  position: relative;
+  border-top: 4px solid transparent;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.team-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 16px 30px rgba(15, 24, 44, 0.12);
+}
+
+.team-card.leader {
+  grid-column: span 2;
+  flex-direction: row;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.team-card.management-card {
+  border-top-color: #ff9f43;
+}
+
+.team-card.research-card {
+  border-top-color: #3498db;
+}
+
+.team-card.finance-card {
+  border-top-color: #f1c40f;
+}
+
+.team-card.marketing-card {
+  border-top-color: #27ae60;
+}
+
+.member-avatar {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: linear-gradient(145deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.08));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: #2c3e50;
+  position: relative;
+  overflow: hidden;
+}
+
+.member-avatar img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}
+
+.member-initials {
+  display: none;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.member-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.member-role {
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #5f6a7d;
+  margin: 0;
+}
+
+.member-name {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.team-card.leader .member-name {
+  font-size: 1.4rem;
+}
+
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .market-movers {
@@ -2437,13 +2619,32 @@ section {
     margin: 20% auto;
     width: 95%;
   }
-  
+
   .form-actions {
     flex-direction: column;
   }
-  
+
   .login-btn, .register-btn {
     width: 100%;
+  }
+
+  .team-section {
+    padding: 0 0.5rem;
+    gap: 2rem;
+  }
+
+  .team-header h2 {
+    font-size: 2rem;
+  }
+
+  .team-card.leader {
+    grid-column: span 1;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .team-grid {
+    gap: 1rem;
   }
 }
 

--- a/nss.html
+++ b/nss.html
@@ -123,6 +123,10 @@
           <img src="about-icon.png" alt="About" class="nav-img">
           <span>About</span>
         </a>
+        <a href="#team" class="nav-icon">
+          <img src="default-avatar.png" alt="Our Team" class="nav-img">
+          <span>Our Team</span>
+        </a>
       </div>
       <div class="nav-right">
         <div class="credits-display">
@@ -433,6 +437,157 @@
               <span class="social-icon">📺</span>
               <span class="social-text" data-translate="youtube">YouTube</span>
             </a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="team" style="display: none;">
+      <div class="team-section">
+        <div class="team-header">
+          <h2>Our Team</h2>
+          <p>Meet the passionate people guiding the Nepal Stock Simulator and supporting our community of investors.</p>
+        </div>
+
+        <div class="team-category">
+          <div class="category-header">
+            <span class="category-label management">Management &amp; Operations</span>
+          </div>
+          <div class="team-grid">
+            <article class="team-card leader management-card">
+              <div class="member-avatar">
+                <img src="subigya.png" alt="Subigya Raj Kharel" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">SRK</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">Chief Executive Officer</p>
+                <h3 class="member-name">Subigya Raj Kharel</h3>
+              </div>
+            </article>
+            <article class="team-card management-card">
+              <div class="member-avatar">
+                <img src="angi.png" alt="Angi Rijal" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">AR</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">Chief Operating Officer</p>
+                <h3 class="member-name">Angi Rijal</h3>
+              </div>
+            </article>
+            <article class="team-card management-card">
+              <div class="member-avatar">
+                <img src="nayan.png" alt="Nayan Shakya" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">NS</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">Managing Director</p>
+                <h3 class="member-name">Nayan Shakya</h3>
+              </div>
+            </article>
+            <article class="team-card management-card">
+              <div class="member-avatar">
+                <img src="abhinav.png" alt="Abhinav Pyakurel" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">AP</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">Deputy Chief Operating Officer</p>
+                <h3 class="member-name">Abhinav Pyakurel</h3>
+              </div>
+            </article>
+          </div>
+        </div>
+
+        <div class="team-category">
+          <div class="category-header">
+            <span class="category-label research">Research &amp; Development</span>
+          </div>
+          <div class="team-grid">
+            <article class="team-card research-card">
+              <div class="member-avatar">
+                <img src="aarohan.png" alt="Aarohan Timalsina" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">AT</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">AI Researcher</p>
+                <h3 class="member-name">Aarohan Timalsina</h3>
+              </div>
+            </article>
+            <article class="team-card research-card">
+              <div class="member-avatar">
+                <img src="aayim.png" alt="Aayim Rijal" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">AR</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">Chief Technology Officer</p>
+                <h3 class="member-name">Aayim Rijal</h3>
+              </div>
+            </article>
+            <article class="team-card research-card">
+              <div class="member-avatar">
+                <img src="samyam.png" alt="Samyam Giri" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">SG</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">SVP of Research</p>
+                <h3 class="member-name">Samyam Giri</h3>
+              </div>
+            </article>
+          </div>
+        </div>
+
+        <div class="team-category">
+          <div class="category-header">
+            <span class="category-label finance">Finances</span>
+          </div>
+          <div class="team-grid single">
+            <article class="team-card finance-card">
+              <div class="member-avatar">
+                <img src="rachit.png" alt="Rachit Bhattarai" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">RB</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">Chief Financial Officer</p>
+                <h3 class="member-name">Rachit Bhattarai</h3>
+              </div>
+            </article>
+          </div>
+        </div>
+
+        <div class="team-category">
+          <div class="category-header">
+            <span class="category-label marketing">Marketing &amp; Communications</span>
+          </div>
+          <div class="team-grid">
+            <article class="team-card marketing-card">
+              <div class="member-avatar">
+                <img src="rushka.png" alt="Rushka Sapkota" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">RS</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">Chief Marketing Officer</p>
+                <h3 class="member-name">Rushka Sapkota</h3>
+              </div>
+            </article>
+            <article class="team-card marketing-card">
+              <div class="member-avatar">
+                <img src="sanskari.png" alt="Sanskari Sharma" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">SS</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">Content &amp; Communications</p>
+                <h3 class="member-name">Sanskari Sharma</h3>
+              </div>
+            </article>
+            <article class="team-card marketing-card">
+              <div class="member-avatar">
+                <img src="aarav.png" alt="Aarav Dahal" onerror="this.remove(); this.parentElement.querySelector('.member-initials').style.display='flex';">
+                <span class="member-initials" aria-hidden="true">AD</span>
+              </div>
+              <div class="member-info">
+                <p class="member-role">VP of Communications</p>
+                <h3 class="member-name">Aarav Dahal</h3>
+              </div>
+            </article>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add an Our Team navigation link and section showcasing leadership and department cards
- provide placeholders and fallback initials for each teammate portrait
- style the team grid with color-coded categories and responsive behaviour

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e68bfd0da8832e8f79d23c62b09ef5